### PR TITLE
Adding reshab staff info to site

### DIFF
--- a/_staffers/reshab.md
+++ b/_staffers/reshab.md
@@ -1,0 +1,9 @@
+---
+name: Reshab (Río) Chhabra
+role: Teaching Assistant
+email: reshabc@bu.edu
+lab: TBD!
+photo: reshab.jpg
+---
+
+Office Hours: TBD! Location: TBD!


### PR DESCRIPTION
Adding `reshab` to Fall 2023 page. Note image is not added again since it was added in the prior Spring 2023 semester.