### PR TITLE
Update to Technical PM info

### DIFF
--- a/_staffers/MatthewBatacan.md
+++ b/_staffers/MatthewBatacan.md
@@ -1,6 +1,6 @@
 ---
 name: Matthew Batacan
-role: Technical PM
+role: Technical Project Manager
 email: mbatacan@bu.edu
 projects: Police Overtime, BU Athletics Academic Performance
 lab: Thursday (2:30PM - 2:50PM) & (5:00PM - 5:50PM), Friday (10:10AM - 11:00AM)

--- a/staff.md
+++ b/staff.md
@@ -22,7 +22,7 @@ description: A listing of all the course staff members.
 {% assign num_teaching_assistants = teaching_assistants | size %}
 {% if num_teaching_assistants != 0 %}
 
-{% assign technical_pm = site.staffers | where: 'role', 'Teachnical Project Manager' %}
+{% assign technical_pm = site.staffers | where: 'role', 'Technical Project Manager' %}
 {% assign num_tpm = technical_pm | size %}
 {% if num_tpm != 0 %}
 


### PR DESCRIPTION
@gallettilance I had checked on the website to see if our information was showing up on the staff section, but noticed that it wasn't there. I caught a typo in the staff.md where the role was checking for Teachnical Project Manager instead of Technical Project Manager. Also updated my section to match the role.