### PR TITLE
Syntax error causing build fail

### DIFF
--- a/_staffers/MatthewBatacan.md
+++ b/_staffers/MatthewBatacan.md
@@ -1,6 +1,6 @@
 ---
 name: Matthew Batacan
-role: Technical PM
+role: Technical Project Manager
 email: mbatacan@bu.edu
 projects: Police Overtime, BU Athletics Academic Performance
 lab: Thursday (2:30PM - 2:50PM) & (5:00PM - 5:50PM), Friday (10:10AM - 11:00AM)

--- a/staff.md
+++ b/staff.md
@@ -35,7 +35,7 @@ description: A listing of all the course staff members.
 
 # Technical Project Managers
 
-{$ for staffer in technical_pm %}
+{% for staffer in technical_pm %}
 {{ staffer }}
 {% endfor %}
 {% endif % }

--- a/staff.md
+++ b/staff.md
@@ -22,7 +22,7 @@ description: A listing of all the course staff members.
 {% assign num_teaching_assistants = teaching_assistants | size %}
 {% if num_teaching_assistants != 0 %}
 
-{% assign technical_pm = site.staffers | where: 'role', 'Teachnical Project Manager' %}
+{% assign technical_pm = site.staffers | where: 'role', 'Technical Project Manager' %}
 {% assign num_tpm = technical_pm | size %}
 {% if num_tpm != 0 %}
 


### PR DESCRIPTION
I just checked again and it looked like there was still a problem with some syntax within `staff.md` causing the build to fail. Updated line 38 from {$ for staffer in teaching_assistants %} to {% for staffer in teaching_assistants %}. Hopefull this fixes the error so that the TPMs info is displayed on the site.